### PR TITLE
feature: let Peastash be safe

### DIFF
--- a/spec/peastash/middleware_spec.rb
+++ b/spec/peastash/middleware_spec.rb
@@ -110,6 +110,7 @@ describe Peastash::Middleware do
 
     context "exception in before / after block" do
       before :each do
+        Peastash.safe!
         before_block = ->(env, request) { 1 / 0 }
         after_block = ->(env, request) { unknown_method }
         @middleware = Peastash::Middleware.new(app, before_block, after_block)
@@ -130,6 +131,7 @@ describe Peastash::Middleware do
     end
 
     it "doesn't catch exception in the app" do
+      Peastash.safe!
       app = ->(env) { raise }
       @middleware = Peastash::Middleware.new(app)
       expect {

--- a/spec/peastash_spec.rb
+++ b/spec/peastash_spec.rb
@@ -125,6 +125,45 @@ describe Peastash do
       end
     end
 
+    describe ".safely" do
+      context "when safe" do
+        before { Peastash.safe! }
+
+        it 'rescues errors silently' do
+          expect {
+            Peastash.safely { 1 / 0 }
+          }.not_to raise_error
+        end
+
+        it 'returns value returned from the block' do
+          expect(Peastash.safely { "test" }).to eq("test")
+        end
+
+        it "puts the error to STDERR for easy debugging" do
+          expect(STDERR).to receive(:puts)
+          Peastash.safely { 1 / 0 }
+        end
+      end
+
+      context "when unsafe" do
+        before { Peastash.unsafe! }
+
+        it 'doesn\'t rescue errors silently' do
+          expect {
+            Peastash.safely { 1 / 0 }
+          }.to raise_error(ZeroDivisionError)
+        end
+
+        it "puts the error to STDERR for easy debugging" do
+          expect(STDERR).to receive(:puts)
+
+          expect {
+            Peastash.safely { 1 / 0 }
+          }.to raise_error(ZeroDivisionError)
+        end
+      end
+    end
+
     describe "#tags" do
       it "calls configure beforehand if instance isn't configured" do
         expect(Peastash.with_instance).to receive(:configure!).and_call_original

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,11 @@ RSpec.configure do |config|
     # Muting the output from the logger
     Peastash::Outputs::IO.class_variable_set(:@@default_io, File.open(File::NULL, File::WRONLY))
   end
+
+  config.before(:each) do
+    # For the errors to be raised
+    Peastash.unsafe!
+  end
 end
 
 def unconfigure_foostash!


### PR DESCRIPTION
As we place the middleware before ActionDispatch::ShowExceptions, we must ensure that everything can't raise. Because, if there is an error, we'll have the process terminated and a 502 bad gateway error.

This allow to ensure that @app.call is always called and its response returned.
