### PR TITLE
Feature: Add the PID to the events

### DIFF
--- a/lib/peastash.rb
+++ b/lib/peastash.rb
@@ -115,6 +115,11 @@ class Peastash
   end
 
   def build_event(source, tags)
-    LogStash::Event.new('@source' => source, '@fields' => store, '@tags' => @base_tags + tags)
+    LogStash::Event.new({
+      '@source' => source,
+      '@fields' => store,
+      '@tags' => @base_tags + tags,
+      '@pid' => Process.pid
+    })
   end
 end

--- a/spec/peastash/middleware_spec.rb
+++ b/spec/peastash/middleware_spec.rb
@@ -53,7 +53,8 @@ describe Peastash::Middleware do
         expect(LogStash::Event).to receive(:new).with({
           '@source' => Peastash::STORE_NAME,
           '@fields' => { path: '/', duration: 0, status: 200, ip: nil },
-          '@tags' => []
+          '@tags' => [],
+          '@pid' => an_instance_of(Fixnum),
         })
         Timecop.freeze { @middleware.call env_for('/') }
       end
@@ -78,7 +79,8 @@ describe Peastash::Middleware do
         expect(LogStash::Event).to receive(:new).with({
           '@source' => Peastash::STORE_NAME,
           '@fields' => { scheme: 'http', duration: 0, status: 200, ip: nil },
-          '@tags' => []
+          '@tags' => [],
+          '@pid' => an_instance_of(Fixnum),
         })
         Timecop.freeze { @middleware.call env_for('/') }
       end
@@ -103,6 +105,7 @@ describe Peastash::Middleware do
           '@source' => Peastash::STORE_NAME,
           '@fields' => { duration: 0, status: 200, foo: 'foo', ip: nil },
           '@tags' => [],
+          '@pid' => an_instance_of(Fixnum),
         })
         Timecop.freeze { @middleware.call env_for('/') }
       end

--- a/spec/peastash_spec.rb
+++ b/spec/peastash_spec.rb
@@ -35,8 +35,9 @@ describe Peastash do
         Peastash.with_instance.configure!(tags: tags)
         expect(LogStash::Event).to receive(:new).with({
           '@source' => Peastash::STORE_NAME,
-          '@fields' => {},
-          '@tags' => tags
+          '@fields' => an_instance_of(Hash),
+          '@tags' => tags,
+          '@pid' => an_instance_of(Fixnum),
         })
         Peastash.with_instance.log {}
       end
@@ -45,8 +46,9 @@ describe Peastash do
         Peastash.with_instance.configure!(source: 'foo')
         expect(LogStash::Event).to receive(:new).with({
           '@source' => 'foo',
-          '@fields' => {},
-          '@tags' => []
+          '@fields' => an_instance_of(Hash),
+          '@tags' => [],
+          '@pid' => an_instance_of(Fixnum),
         })
         Peastash.with_instance.log {}
       end
@@ -118,8 +120,9 @@ describe Peastash do
         Peastash.with_instance.configure!(tags: base_tags)
         expect(LogStash::Event).to receive(:new).with({
           '@source' => Peastash::STORE_NAME,
-          '@fields' => {},
-          '@tags' => base_tags + tags
+          '@fields' => an_instance_of(Hash),
+          '@tags' => base_tags + tags,
+          '@pid' => an_instance_of(Fixnum),
         })
         Peastash.with_instance.log(tags) {}
       end
@@ -177,8 +180,9 @@ describe Peastash do
         Peastash.with_instance.configure!(tags: base_tags)
         expect(LogStash::Event).to receive(:new).with({
           '@source' => Peastash::STORE_NAME,
-          '@fields' => {},
-          '@tags' => base_tags + tags + additional_tags
+          '@fields' => an_instance_of(Hash),
+          '@tags' => base_tags + tags + additional_tags,
+          '@pid' => an_instance_of(Fixnum),
         })
         Peastash.with_instance.log(tags) { Peastash.with_instance.tags.concat(additional_tags) }
       end


### PR DESCRIPTION
Yup, here is a small adding to log the PID, which is terribly useful when debugging Passenger process gone rogue (or bloaty). We'll be able to see their last life events in Kibana.