### PR TITLE
Fix IO error in default Rails middleware caused by headers object which is not serializable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: ruby
 rvm:
-  - 2.1.6
-  - 2.2.0
-  - 2.3.0
-  - 2.3.1
-  - jruby-1.7.19
-  - jruby-1.7.20
+  - 2.1.10
+  - 2.2.10
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
+  - jruby-1.7.26
+  - jruby-9.1.9.0
   - jruby-head
 gemfile:
   - gemfiles/Gemfile.rails-3.2.x

--- a/lib/peastash/rails_ext/railtie.rb
+++ b/lib/peastash/rails_ext/railtie.rb
@@ -10,7 +10,7 @@ class Peastash
         Peastash.with_instance.configure!(app.config.peastash)
         ActiveSupport::Notifications.subscribe('process_action.action_controller') do |name, started, finished, unique_id, data|
           # Handle parameters and sanitize if need be
-          to_reject = [:db_runtime, :view_runtime, :exception]
+          to_reject = [:db_runtime, :view_runtime, :exception, :headers]
           payload = data.reject { |key, _| to_reject.include?(key) }
           payload.merge!(db: data[:db_runtime], view: data[:view_runtime])
           payload.merge!(exception: { class: data[:exception].first, message: data[:exception].last[0..200] }) if data.has_key?(:exception)

--- a/spec/peastash/middleware_spec.rb
+++ b/spec/peastash/middleware_spec.rb
@@ -54,7 +54,7 @@ describe Peastash::Middleware do
           '@source' => Peastash::STORE_NAME,
           '@fields' => { path: '/', duration: 0, status: 200, ip: nil },
           '@tags' => [],
-          '@pid' => an_instance_of(Integer),
+          '@pid' => a_kind_of(Numeric),
         })
         Timecop.freeze { @middleware.call env_for('/') }
       end
@@ -66,7 +66,7 @@ describe Peastash::Middleware do
           '@source' => Peastash::STORE_NAME,
           '@fields' => { duration: 0, status: 200, ip: nil, time_in_queue: 0.0 },
           '@tags' => [],
-          '@pid' => an_instance_of(Integer),
+          '@pid' => a_kind_of(Numeric),
         })
         middleware = Peastash::Middleware.new(app)
         Timecop.freeze { middleware.call env_for('/', { 'HTTP_X_REQUEST_START' => Time.now.to_f }) }
@@ -93,7 +93,7 @@ describe Peastash::Middleware do
           '@source' => Peastash::STORE_NAME,
           '@fields' => { scheme: 'http', duration: 0, status: 200, ip: nil },
           '@tags' => [],
-          '@pid' => an_instance_of(Integer),
+          '@pid' => a_kind_of(Numeric),
         })
         Timecop.freeze { @middleware.call env_for('/') }
       end
@@ -118,7 +118,7 @@ describe Peastash::Middleware do
           '@source' => Peastash::STORE_NAME,
           '@fields' => { duration: 0, status: 200, foo: 'foo', ip: nil },
           '@tags' => [],
-          '@pid' => an_instance_of(Integer),
+          '@pid' => a_kind_of(Numeric),
         })
         Timecop.freeze { @middleware.call env_for('/') }
       end

--- a/spec/peastash/middleware_spec.rb
+++ b/spec/peastash/middleware_spec.rb
@@ -54,7 +54,7 @@ describe Peastash::Middleware do
           '@source' => Peastash::STORE_NAME,
           '@fields' => { path: '/', duration: 0, status: 200, ip: nil },
           '@tags' => [],
-          '@pid' => an_instance_of(Fixnum),
+          '@pid' => an_instance_of(Integer),
         })
         Timecop.freeze { @middleware.call env_for('/') }
       end
@@ -66,7 +66,7 @@ describe Peastash::Middleware do
           '@source' => Peastash::STORE_NAME,
           '@fields' => { duration: 0, status: 200, ip: nil, time_in_queue: 0.0 },
           '@tags' => [],
-          '@pid' => an_instance_of(Fixnum),
+          '@pid' => an_instance_of(Integer),
         })
         middleware = Peastash::Middleware.new(app)
         Timecop.freeze { middleware.call env_for('/', { 'HTTP_X_REQUEST_START' => Time.now.to_f }) }
@@ -93,7 +93,7 @@ describe Peastash::Middleware do
           '@source' => Peastash::STORE_NAME,
           '@fields' => { scheme: 'http', duration: 0, status: 200, ip: nil },
           '@tags' => [],
-          '@pid' => an_instance_of(Fixnum),
+          '@pid' => an_instance_of(Integer),
         })
         Timecop.freeze { @middleware.call env_for('/') }
       end
@@ -118,7 +118,7 @@ describe Peastash::Middleware do
           '@source' => Peastash::STORE_NAME,
           '@fields' => { duration: 0, status: 200, foo: 'foo', ip: nil },
           '@tags' => [],
-          '@pid' => an_instance_of(Fixnum),
+          '@pid' => an_instance_of(Integer),
         })
         Timecop.freeze { @middleware.call env_for('/') }
       end

--- a/spec/peastash_spec.rb
+++ b/spec/peastash_spec.rb
@@ -37,7 +37,7 @@ describe Peastash do
           '@source' => Peastash::STORE_NAME,
           '@fields' => an_instance_of(Hash),
           '@tags' => tags,
-          '@pid' => an_instance_of(Integer),
+          '@pid' => a_kind_of(Numeric),
         })
         Peastash.with_instance.log {}
       end
@@ -48,7 +48,7 @@ describe Peastash do
           '@source' => 'foo',
           '@fields' => an_instance_of(Hash),
           '@tags' => [],
-          '@pid' => an_instance_of(Integer),
+          '@pid' => a_kind_of(Numeric),
         })
         Peastash.with_instance.log {}
       end
@@ -122,7 +122,7 @@ describe Peastash do
           '@source' => Peastash::STORE_NAME,
           '@fields' => an_instance_of(Hash),
           '@tags' => base_tags + tags,
-          '@pid' => an_instance_of(Integer),
+          '@pid' => a_kind_of(Numeric),
         })
         Peastash.with_instance.log(tags) {}
       end
@@ -192,7 +192,7 @@ describe Peastash do
           '@source' => Peastash::STORE_NAME,
           '@fields' => an_instance_of(Hash),
           '@tags' => base_tags + tags + additional_tags,
-          '@pid' => an_instance_of(Integer),
+          '@pid' => a_kind_of(Numeric),
         })
         Peastash.with_instance.log(tags) { Peastash.with_instance.tags.concat(additional_tags) }
       end

--- a/spec/peastash_spec.rb
+++ b/spec/peastash_spec.rb
@@ -37,7 +37,7 @@ describe Peastash do
           '@source' => Peastash::STORE_NAME,
           '@fields' => an_instance_of(Hash),
           '@tags' => tags,
-          '@pid' => an_instance_of(Fixnum),
+          '@pid' => an_instance_of(Integer),
         })
         Peastash.with_instance.log {}
       end
@@ -48,7 +48,7 @@ describe Peastash do
           '@source' => 'foo',
           '@fields' => an_instance_of(Hash),
           '@tags' => [],
-          '@pid' => an_instance_of(Fixnum),
+          '@pid' => an_instance_of(Integer),
         })
         Peastash.with_instance.log {}
       end
@@ -122,7 +122,7 @@ describe Peastash do
           '@source' => Peastash::STORE_NAME,
           '@fields' => an_instance_of(Hash),
           '@tags' => base_tags + tags,
-          '@pid' => an_instance_of(Fixnum),
+          '@pid' => an_instance_of(Integer),
         })
         Peastash.with_instance.log(tags) {}
       end
@@ -192,7 +192,7 @@ describe Peastash do
           '@source' => Peastash::STORE_NAME,
           '@fields' => an_instance_of(Hash),
           '@tags' => base_tags + tags + additional_tags,
-          '@pid' => an_instance_of(Fixnum),
+          '@pid' => an_instance_of(Integer),
         })
         Peastash.with_instance.log(tags) { Peastash.with_instance.tags.concat(additional_tags) }
       end


### PR DESCRIPTION
Hi !

I just tried adding `peastash` to updown.io and was greeted with a nice error message after just enabling the default rails integration:
```
#<IOError: not opened for reading>
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.6/lib/active_support/core_ext/object/json.rb:132:in `each'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.6/lib/active_support/core_ext/object/json.rb:132:in `to_a'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.6/lib/active_support/core_ext/object/json.rb:132:in `as_json'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.6/lib/active_support/core_ext/object/json.rb:144:in `block in as_json'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.6/lib/active_support/core_ext/object/json.rb:144:in `map'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.6/lib/active_support/core_ext/object/json.rb:144:in `as_json'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.6/lib/active_support/core_ext/object/json.rb:144:in `block in as_json'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.6/lib/active_support/core_ext/object/json.rb:144:in `map'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.6/lib/active_support/core_ext/object/json.rb:144:in `as_json'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.6/lib/active_support/core_ext/object/json.rb:132:in `as_json'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.6/lib/active_support/core_ext/object/json.rb:163:in `block in as_json'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.6/lib/active_support/core_ext/object/json.rb:163:in `each'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.6/lib/active_support/core_ext/object/json.rb:163:in `map'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.6/lib/active_support/core_ext/object/json.rb:163:in `as_json'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.6/lib/active_support/core_ext/object/json.rb:163:in `block in as_json'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.6/lib/active_support/core_ext/object/json.rb:163:in `each'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.6/lib/active_support/core_ext/object/json.rb:163:in `map'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.6/lib/active_support/core_ext/object/json.rb:163:in `as_json'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.6/lib/active_support/json/encoding.rb:33:in `encode'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.6/lib/active_support/json/encoding.rb:20:in `encode'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.6/lib/active_support/core_ext/object/json.rb:39:in `to_json'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/logstash-event-1.2.02/lib/logstash/event.rb:169:in `to_json'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/peastash-0.2.2/lib/peastash/outputs/io.rb:17:in `dump'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/peastash-0.2.2/lib/peastash.rb:88:in `block in log'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/peastash-0.2.2/lib/peastash.rb:21:in `safely'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/peastash-0.2.2/lib/peastash.rb:85:in `log'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/peastash-0.2.2/lib/peastash/middleware.rb:13:in `call'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/railties-5.1.6/lib/rails/rack/logger.rb:36:in `call_app'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/railties-5.1.6/lib/rails/rack/logger.rb:24:in `block in call'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.6/lib/active_support/tagged_logging.rb:69:in `block in tagged'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.6/lib/active_support/tagged_logging.rb:26:in `tagged'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.6/lib/active_support/tagged_logging.rb:69:in `tagged'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/railties-5.1.6/lib/rails/rack/logger.rb:24:in `call'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sprockets-rails-3.2.1/lib/sprockets/rails/quiet_assets.rb:13:in `call'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionpack-5.1.6/lib/action_dispatch/middleware/remote_ip.rb:79:in `call'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionpack-5.1.6/lib/action_dispatch/middleware/request_id.rb:25:in `call'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rack-2.0.5/lib/rack/method_override.rb:22:in `call'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rack-2.0.5/lib/rack/runtime.rb:22:in `call'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionpack-5.1.6/lib/action_dispatch/middleware/executor.rb:12:in `call'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/actionpack-5.1.6/lib/action_dispatch/middleware/static.rb:125:in `call'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rack-2.0.5/lib/rack/sendfile.rb:111:in `call'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rack-cors-1.0.2/lib/rack/cors.rb:97:in `call'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sentry-raven-2.7.2/lib/raven/integrations/rack.rb:51:in `call'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/railties-5.1.6/lib/rails/engine.rb:522:in `call'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/puma-3.11.4/lib/puma/configuration.rb:225:in `call'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/puma-3.11.4/lib/puma/server.rb:632:in `handle_request'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/puma-3.11.4/lib/puma/server.rb:446:in `process_client'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/puma-3.11.4/lib/puma/server.rb:306:in `block in run'
/home/bigbourin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/puma-3.11.4/lib/puma/thread_pool.rb:120:in `block in spawn_thread'
```

After some digging I found this is caused by the `headers` attribute which is kept in the payload and is impossible to serialize because it contains very complex objects, including references to the entire request and it's body. I'm not sure if this is actually working with other rails versions (i'm using `5.1.6` with puma in dev) but at least at dimelo, not headers are even present in kibana. IMO we should simply ignore this headers part – which is probably broken ­– as it could be a huge waste of space in the instrumentation.

I tried to write some specs but It's a pain, I couldn't make a dummy rails 5 app work and anyway I guess it needs a real server to reproduce as a testing rack request may actually be serializable (no socket). I can just test that headers is not present, but I didn't saw any other spec checking other attributes so I'll add one if you want.

Oh and I updated the `Fixnum` references to avoid deprecation warnings when running specs.