### PR TITLE
Allow LogDevice default options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ gemfile:
   - gemfiles/Gemfile.rails-head
 script:
   - bundle exec rspec
-before_install: 'gem install bundler'
+before_install: 'gem install bundler -v 1.17'
 matrix:
   allow_failures:
     - gemfile: gemfiles/Gemfile.rails-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,9 @@ gemfile:
   - gemfiles/Gemfile.rails-head
 script:
   - bundle exec rspec
-before_install: 'gem install bundler -v 1.17'
+before_install:
+  - 'gem uninstall bundler -x || gem uninstall bundler -a || true'
+  - 'gem install bundler -v 1.17'
 matrix:
   allow_failures:
     - gemfile: gemfiles/Gemfile.rails-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,9 @@ gemfile:
 script:
   - bundle exec rspec
 before_install:
-  - 'gem uninstall bundler -x || gem uninstall bundler -a || true'
-  - 'gem install bundler -v 1.17'
+  - rvm use @global
+  - gem uninstall bundler -x || gem uninstall bundler -a || true
+  - gem install bundler -v 1.17
 matrix:
   allow_failures:
     - gemfile: gemfiles/Gemfile.rails-head

--- a/lib/peastash/outputs/io.rb
+++ b/lib/peastash/outputs/io.rb
@@ -9,8 +9,8 @@ class Peastash
         @@default_io
       end
 
-      def initialize(file)
-        @device = ::Peastash::LogDevice.new(file)
+      def initialize(file, **args)
+        @device = ::Peastash::LogDevice.new(file, **args)
       end
 
       def dump(event)

--- a/lib/peastash/outputs/io.rb
+++ b/lib/peastash/outputs/io.rb
@@ -9,8 +9,8 @@ class Peastash
         @@default_io
       end
 
-      def initialize(file, **args)
-        @device = ::Peastash::LogDevice.new(file, **args)
+      def initialize(file, *args)
+        @device = ::Peastash::LogDevice.new(file, *args)
       end
 
       def dump(event)


### PR DESCRIPTION
Hello there ! Hope everything is alright :)

This MR allows the `Peastash::Outputs::IO` object to receive `Logger::LogDevice` supplementary arguments such as `shift_age` and `shift_size`

https://ruby-doc.org/stdlib-2.5.3/libdoc/logger/rdoc/Logger/LogDevice.html

Context: since we're not using logstash anymore to load the data into redis, it is necessary for us to increase the files size because Peastash currently fills a file faster than filebeat check speed (every 10 seconds by default). LogDevice creates files of 1MB by default so I guess we can afford more :p