### PR TITLE
Better: Allow to pass before/after blocks for middleware with rails.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ config.peastash.enabled = true
 # You can also configure Peastash from here, for example:
 config.peastash.output = Peastash::Outputs::IO.new(File.join(Rails.root, 'log', "logstash_#{Rails.env}.log"))
 config.peastash.source = Rails.application.class.parent_name
+config.peastash.before_block = ->(env, response) { Peastash.with_instance.store[:path] = Rack::Request.new(env).path }
+config.peastash.after_block = ->(env, response) { Peastash.with_instance.store[:puma_wait] = env['puma.request_body_wait'] }
 ```
 
 By default, Peastash's Rails integration will log the same parameters as the Middleware version, plus the fields in the payload of the [``process_action.action_controller``](http://edgeguides.rubyonrails.org/active_support_instrumentation.html#process_action.action_controller) notification (except the params).

--- a/lib/peastash/rails_ext/railtie.rb
+++ b/lib/peastash/rails_ext/railtie.rb
@@ -23,7 +23,7 @@ class Peastash
           Peastash.with_instance.store.merge!(payload) { |key, old_val, new_val| old_val }
         end
         before_middleware = app.config.peastash[:insert_before] || ActionDispatch::ShowExceptions
-        app.config.middleware.insert_before before_middleware, Peastash::Middleware
+        app.config.middleware.insert_before before_middleware, Peastash::Middleware, app.config.peastash[:before_block], app.config.peastash[:after_block]
       end
     end
   end


### PR DESCRIPTION
Peastash::Middleware has some options (before / after blocks) that can't be set when the middleware is automatically inserted into the rails middelwares stack

This PR allows to set those options through `config.peastash`