### PR TITLE
Better: Rescue ENOENT error writing into /tmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ If the argument is a path to a non-writeable file, Peastash will attempt to dele
 Peastash can easily be extended to output to any target.
 Simply configure Peastash's output with an object that responds to the ``#dump`` method. This method will be called at the end of the ``#log`` block, with 1 argument: a ``LogStash::Event`` object that you will probably need to serialize to json.
 
+In case the directory doesn't exist, peastash won't crash, a tempfile will be created in /tmp (or $TMPDIR) and the data will be stored in this file. The full path of this tempfile will be printed to STDERR so it can easily be retrieved.
+
 ### What if I want to use it in my rack app?
 
 There's a middleware for that! Simply add the following somewhere:

--- a/lib/peastash/log_device.rb
+++ b/lib/peastash/log_device.rb
@@ -11,7 +11,7 @@ class Peastash
       FileUtils.rm(filename)
       create_logfile(filename)
     rescue Errno::ENOENT => e
-      temp_file = Tempfile.new([filename, 'log'])
+      temp_file = Tempfile.new([filename, '.log'])
       STDERR.puts "[#{Time.now}][#{Process.pid}] Could not open #{filename} for writing: #{e.message}. Data will be writen in: #{temp_file.path}"
       open_logfile(temp_file.path)
     end

--- a/lib/peastash/log_device.rb
+++ b/lib/peastash/log_device.rb
@@ -11,6 +11,7 @@ class Peastash
       FileUtils.rm(filename)
       create_logfile(filename)
     rescue Errno::ENOENT => e
+      require 'tempfile'
       temp_file = Tempfile.new([filename, '.log'])
       STDERR.puts "[#{Time.now}][#{Process.pid}] Could not open #{filename} for writing: #{e.message}. Data will be writen in: #{temp_file.path}"
       open_logfile(temp_file.path)

--- a/lib/peastash/log_device.rb
+++ b/lib/peastash/log_device.rb
@@ -10,6 +10,10 @@ class Peastash
       STDERR.puts "[#{Time.now}][#{Process.pid}] Could not open #{filename} for writing, recreating it. Info: #{stat_data.inspect}"
       FileUtils.rm(filename)
       create_logfile(filename)
+    rescue Errno::ENOENT => e
+      temp_file = Tempfile.new([filename, 'log'])
+      STDERR.puts "[#{Time.now}][#{Process.pid}] Could not open #{filename} for writing: #{e.message}. Data will be writen in: #{temp_file.path}"
+      open_logfile(temp_file.path)
     end
   end
 end


### PR DESCRIPTION
Adding more safety to peastash.

If you try to log in a non existing folder, the whole process will crash. (This can happen with capistrano for instance where you keep the last n-th releases)

This PR rescue the ENOENT error and create a tempfile and start writing into it.
An error message is displayed in STDERR to explain the root error and give the new file path

Error message looks like : 

```
[2019-05-27 18:15:22 +0200][122] Could not open /drone/src/git/project/logaa/logstash_test.log for writing: No such file or directory @ rb_sysopen - /drone/src/git/project/logaa/logstash_test.log. Data will be writen in: /tmp/dronesrcgitprojectlogaalogstash_test.log20190527-122-1nel6sz.log
```
