### PR TITLE
Better: Use realpath for logdevice.

### DIFF
--- a/lib/peastash/outputs/io.rb
+++ b/lib/peastash/outputs/io.rb
@@ -10,9 +10,12 @@ class Peastash
       end
 
       def initialize(file, *args)
-        dir = File.realpath(File.dirname(file))
-        name = File.basename(file)
-        @device = ::Peastash::LogDevice.new("#{dir}/#{name}", *args)
+        file = if file.is_a?(String)
+                 dir = File.realpath(File.dirname(file))
+                 name = File.basename(file)
+                 "#{dir}/#{name}"
+               end
+        @device = ::Peastash::LogDevice.new(file, *args)
       end
 
       def dump(event)

--- a/lib/peastash/outputs/io.rb
+++ b/lib/peastash/outputs/io.rb
@@ -10,7 +10,9 @@ class Peastash
       end
 
       def initialize(file, *args)
-        @device = ::Peastash::LogDevice.new(file, *args)
+        dir = File.realpath(File.dirname(file))
+        name = File.basename(file)
+        @device = ::Peastash::LogDevice.new("#{dir}/#{name}", *args)
       end
 
       def dump(event)

--- a/lib/peastash/outputs/io.rb
+++ b/lib/peastash/outputs/io.rb
@@ -10,11 +10,16 @@ class Peastash
       end
 
       def initialize(file, *args)
-        file = if file.is_a?(String)
-                 dir = File.realpath(File.dirname(file))
-                 name = File.basename(file)
-                 "#{dir}/#{name}"
-               end
+        if file.is_a?(String)
+          # Rewrite symlink path to realpath for instance
+          # /home/app/releases/20190528155050/log/logstash.log -> /home/app/shared/log/logstash.log
+          # if the symlinked folder gets deleted on further releases, the log rotation will fail with
+          # a long wait ending with : log rotation inter-process lock failed.
+          # realpath is called without the filename because it expects the full path to exists
+          dir = File.realpath(File.dirname(file))
+          name = File.basename(file)
+          file = "#{dir}/#{name}"
+        end
         @device = ::Peastash::LogDevice.new(file, *args)
       end
 


### PR DESCRIPTION
So PR is in order to prevent a bug during log rotation.

If the path to the log file doesn't exist anymore, the log rotation will be stuck for a moment and return this error: `log rotation inter-process lock failed.`

This occurs for example with capistrano who deletes older releases folders. To avoid this error, the file path is resolved to the real path which is not deleted upon releases