### PR TITLE
Change scoping of temporary tags

### DIFF
--- a/lib/peastash.rb
+++ b/lib/peastash.rb
@@ -94,7 +94,8 @@ class Peastash
   def tags
     Peastash.safely do
       configure! unless configured?
-      Thread.current[@store_name + ":tags"] ||= []
+      Thread.current[instance_name] ||= Hash.new
+      Thread.current[instance_name][@store_name + ":tags"] ||= []
     end
   end
 

--- a/lib/peastash.rb
+++ b/lib/peastash.rb
@@ -87,6 +87,7 @@ class Peastash
         event = build_event(@source, tags)
         @output.dump(event)
       end
+      tags.clear
     end
   end
 

--- a/peastash.gemspec
+++ b/peastash.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "thread_safe"
 
   gem.add_development_dependency "rake"
-  gem.add_development_dependency "rspec", '~> 2.14'
+  gem.add_development_dependency "rspec", '~> 3.11'
   gem.add_development_dependency "rspec-rails"
   gem.add_development_dependency "rack-test"
   gem.add_development_dependency "simplecov", '~> 0.7.1'

--- a/spec/peastash_spec.rb
+++ b/spec/peastash_spec.rb
@@ -196,6 +196,16 @@ describe Peastash do
         })
         Peastash.with_instance.log(tags) { Peastash.with_instance.tags.concat(additional_tags) }
       end
+
+      describe 'tags scoping' do
+        it 'doesn\'t add additional tags to the instance itself' do
+          base_tags = %w(foo bar)
+          additional_tags = 'qux'
+          expect do
+            Peastash.with_instance.log { Peastash.with_instance.tags << additional_tags }
+          end.not_to change { Peastash.with_instance.tags }
+        end
+      end
     end
 
   end

--- a/spec/peastash_spec.rb
+++ b/spec/peastash_spec.rb
@@ -205,6 +205,11 @@ describe Peastash do
             Peastash.with_instance.log { Peastash.with_instance.tags << additional_tags }
           end.not_to change { Peastash.with_instance.tags }
         end
+
+        it 'does not share tags between instances' do
+          Peastash.with_instance.tags << 'global'
+          expect(Peastash.with_instance(:test).tags).not_to include('global')
+        end
       end
     end
 


### PR DESCRIPTION
Solves https://github.com/elhu/peastash/issues/20.

This PR introduces two changes:
1. Tags are cleared before exiting the `#log` block
2. Tags are scoped to a specific `Peastash` instance.