### PR TITLE
Better: LogDevice compatibility with ruby3

### DIFF
--- a/lib/peastash/outputs/io.rb
+++ b/lib/peastash/outputs/io.rb
@@ -9,7 +9,7 @@ class Peastash
         @@default_io
       end
 
-      def initialize(file, *args)
+      ruby2_keywords def initialize(file, *args)
         if file.is_a?(String)
           # Rewrite symlink path to realpath for instance
           # /home/app/releases/20190528155050/log/logstash.log -> /home/app/shared/log/logstash.log

--- a/peastash.gemspec
+++ b/peastash.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "logstash-event"
   gem.add_runtime_dependency "thread_safe"
+  gem.add_runtime_dependency "ruby2_keywords"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", '~> 2.14'

--- a/spec/peastash/outputs/io_spec.rb
+++ b/spec/peastash/outputs/io_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+require 'peastash/outputs/io'
+
+describe Peastash::Outputs::IO do
+  it 'creates a logdevice' do
+    io = Peastash::Outputs::IO.new('/dev/null', shift_size: 10)
+    expect(io.instance_variable_get("@device").instance_variable_get("@shift_size")).to eq(10)
+  end
+end


### PR DESCRIPTION
When using peastash with ruby >= 3 and the following config:

```ruby
config.peastash.output = Peastash::Outputs::IO.new("#{Rails.root}/log/logstash_#{Rails.env}.log", shift_size: 100.megabytes)
```

we get the following error

```
/home/ylecuyer/.rbenv/versions/3.0.4/lib/ruby/3.0.0/logger/log_device.rb:14:in `initialize': wrong number of arguments (given 2, expected 0..1) (ArgumentError)
	from /home/ylecuyer/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/peastash-0.2.6/lib/peastash/outputs/io.rb:23:in `new'
	from /home/ylecuyer/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/peastash-0.2.6/lib/peastash/outputs/io.rb:23:in `initialize'
```

This PR fixes that keeping compatibility with older rubies