### PR TITLE
Explicitly require ruby2_keywords

### DIFF
--- a/lib/peastash/outputs/io.rb
+++ b/lib/peastash/outputs/io.rb
@@ -1,4 +1,5 @@
 require 'peastash/log_device'
+require 'ruby2_keywords'
 
 class Peastash
   module Outputs


### PR DESCRIPTION
Specs fail on ruby < 2.7, this PR fixes that.